### PR TITLE
webos-initscripts: Add bootd and pdm

### DIFF
--- a/files/systemd/targets/default-webos.target
+++ b/files/systemd/targets/default-webos.target
@@ -19,5 +19,6 @@
 [Unit]
 Description="%n"
 
-Wants=ls-hubd.service \
+Wants=bootd.service \
+      ls-hubd.service \
       populate-volatile.service 

--- a/files/systemd/targets/webos-dis.target
+++ b/files/systemd/targets/webos-dis.target
@@ -19,7 +19,8 @@ Description="%n"
 
 # webos
 Wants=configurator-db8.service \
-      db8.service
+      db8.service \
+      physical-device-manager.service \
       
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since we added bootd and pdm (physical-device-manager) we need to make sure that the initscripts reflect this as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>